### PR TITLE
routing_core_smart: can't drop/create sequence

### DIFF
--- a/wrapper/routing_core_smart.sql
+++ b/wrapper/routing_core_smart.sql
@@ -689,10 +689,11 @@ BEGIN
 	select relname INTO seqname from pg_class where relname='rownum';
 	
 	IF seqname IS NOT NULL THEN
-	EXECUTE 'drop sequence rownum';
+      PERFORM setval('rownum', 1, false);
+    ELSE
+      EXECUTE 'create sequence rownum';
 	END IF;
 
-	EXECUTE 'create sequence rownum';
 	
         IF s_gid = t_gid THEN
 	  
@@ -1033,10 +1034,10 @@ BEGIN
 	select relname INTO seqname from pg_class where relname='rownum';
 	
 	IF seqname IS NOT NULL THEN
-	EXECUTE 'drop sequence rownum';
+      PERFORM setval('rownum', 1, false);
+    ELSE
+      EXECUTE 'create sequence rownum';
 	END IF;
-
-	EXECUTE 'create sequence rownum';
 	
         IF s_gid = t_gid THEN
 	  


### PR DESCRIPTION
Hello all,

I'm using the routing_core_smart but in my particular postgresql setup the user that makes the query can't create or drop sequences (not the owner of the database).

This pull request proposes to reset the value of the sequence instead of the drop/create.

Comments highly welcome !

Regards, fredj
